### PR TITLE
Port to scala 2.13: make tests pass

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ scmInfo := Some(
   )
 )
 
-scalaVersion := "3.2.2"
+scalaVersion := "2.13.10"
 
 lazy val versions = new {
   val zio     = "2.0.10"

--- a/src/main/scala/zio/lmdb/LMDB.scala
+++ b/src/main/scala/zio/lmdb/LMDB.scala
@@ -16,11 +16,9 @@
 
 package zio.lmdb
 
-import zio.*
-import zio.json.*
+import zio._
+import zio.json._
 import zio.stream.ZStream
-import zio.lmdb.StorageUserError.*
-import zio.lmdb.StorageSystemError
 
 trait LMDB {
   def platformCheck(): IO[StorageSystemError, Unit]
@@ -29,27 +27,27 @@ trait LMDB {
 
   def collectionExists(name: CollectionName): IO[StorageSystemError, Boolean]
 
-  def collectionCreate[T](name: CollectionName)(using JsonEncoder[T], JsonDecoder[T]): IO[CollectionAlreadExists | StorageSystemError, LMDBCollection[T]]
+  def collectionCreate[T](name: CollectionName)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): IO[LmdbError, LMDBCollection[T]]
 
-  def collectionAllocate(name: CollectionName):IO[CollectionAlreadExists | StorageSystemError, Unit]
+  def collectionAllocate(name: CollectionName):IO[LmdbError, Unit]
 
-  def collectionGet[T](name: CollectionName)(using JsonEncoder[T], JsonDecoder[T]): IO[CollectionNotFound | StorageSystemError, LMDBCollection[T]]
+  def collectionGet[T](name: CollectionName)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): IO[LmdbError, LMDBCollection[T]]
 
-  def collectionSize(name: CollectionName): IO[CollectionNotFound | StorageSystemError, Long]
+  def collectionSize(name: CollectionName): IO[LmdbError, Long]
 
-  def collectionClear(name: CollectionName): IO[CollectionNotFound | StorageSystemError, Unit]
+  def collectionClear(name: CollectionName): IO[LmdbError, Unit]
 
-  def fetch[T](collectionName: CollectionName, key: RecordKey)(using JsonEncoder[T], JsonDecoder[T]): IO[FetchErrors, Option[T]]
+  def fetch[T](collectionName: CollectionName, key: RecordKey)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): IO[FetchErrors, Option[T]]
 
-  def upsertOverwrite[T](collectionName: CollectionName, key: RecordKey, document: T)(using JsonEncoder[T], JsonDecoder[T]): IO[UpsertErrors, UpsertState[T]]
+  def upsertOverwrite[T](collectionName: CollectionName, key: RecordKey, document: T)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): IO[UpsertErrors, UpsertState[T]]
 
-  def upsert[T](collectionName: CollectionName, key: RecordKey, modifier: Option[T] => T)(using JsonEncoder[T], JsonDecoder[T]): IO[UpsertErrors, UpsertState[T]]
+  def upsert[T](collectionName: CollectionName, key: RecordKey, modifier: Option[T] => T)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): IO[UpsertErrors, UpsertState[T]]
 
-  def delete[T](collectionName: CollectionName, key: RecordKey)(using JsonEncoder[T], JsonDecoder[T]): IO[DeleteErrors, Option[T]]
+  def delete[T](collectionName: CollectionName, key: RecordKey)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): IO[DeleteErrors, Option[T]]
 
-  def collect[T](collectionName: CollectionName, keyFilter: RecordKey => Boolean = _ => true, valueFilter: T => Boolean = (_: T) => true)(using JsonEncoder[T], JsonDecoder[T]): IO[CollectErrors, List[T]]
+  def collect[T](collectionName: CollectionName, keyFilter: RecordKey => Boolean = _ => true, valueFilter: T => Boolean = (_: T) => true)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): IO[CollectErrors, List[T]]
 
-  //def stream[T](collectionName: CollectionName, keyFilter: RecordKey => Boolean = _ => true)(using JsonEncoder[T], JsonDecoder[T]): ZStream[Scope, CollectErrors, T]
+  //def stream[T](collectionName: CollectionName, keyFilter: RecordKey => Boolean = _ => true)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): ZStream[Scope, CollectErrors, T]
 }
 
 object LMDB {
@@ -60,31 +58,31 @@ object LMDB {
 
   def collectionExists(name: CollectionName): ZIO[LMDB, StorageSystemError, Boolean] = ZIO.serviceWithZIO(_.collectionExists(name))
 
-  def collectionCreate[T](name: CollectionName)(using JsonEncoder[T], JsonDecoder[T]): ZIO[LMDB, CollectionAlreadExists | StorageSystemError, LMDBCollection[T]] = ZIO.serviceWithZIO(_.collectionCreate(name))
+  def collectionCreate[T](name: CollectionName)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): ZIO[LMDB, LmdbError, LMDBCollection[T]] = ZIO.serviceWithZIO(_.collectionCreate(name))
 
-  def collectionAllocate(name: CollectionName):ZIO[LMDB, CollectionAlreadExists | StorageSystemError, Unit] = ZIO.serviceWithZIO(_.collectionAllocate(name))
+  def collectionAllocate(name: CollectionName):ZIO[LMDB, LmdbError, Unit] = ZIO.serviceWithZIO(_.collectionAllocate(name))
 
-  def collectionGet[T](name: CollectionName)(using JsonEncoder[T], JsonDecoder[T]): ZIO[LMDB, CollectionNotFound | StorageSystemError, LMDBCollection[T]] = ZIO.serviceWithZIO(_.collectionGet(name))
+  def collectionGet[T](name: CollectionName)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): ZIO[LMDB, LmdbError, LMDBCollection[T]] = ZIO.serviceWithZIO(_.collectionGet(name))
 
-  def collectionSize(name: CollectionName): ZIO[LMDB, CollectionNotFound | StorageSystemError, Long] = ZIO.serviceWithZIO(_.collectionSize(name))
+  def collectionSize(name: CollectionName): ZIO[LMDB, LmdbError, Long] = ZIO.serviceWithZIO(_.collectionSize(name))
 
-  def collectionClear(name: CollectionName): ZIO[LMDB, CollectionNotFound | StorageSystemError, Unit] = ZIO.serviceWithZIO(_.collectionClear(name))
+  def collectionClear(name: CollectionName): ZIO[LMDB, LmdbError, Unit] = ZIO.serviceWithZIO(_.collectionClear(name))
 
-  def fetch[T](collectionName: CollectionName, key: RecordKey)(using JsonEncoder[T], JsonDecoder[T]): ZIO[LMDB, FetchErrors, Option[T]] = ZIO.serviceWithZIO(_.fetch(collectionName, key))
+  def fetch[T](collectionName: CollectionName, key: RecordKey)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): ZIO[LMDB, FetchErrors, Option[T]] = ZIO.serviceWithZIO(_.fetch(collectionName, key))
 
-  def upsert[T](collectionName: CollectionName, key: RecordKey, modifier: Option[T] => T)(using JsonEncoder[T], JsonDecoder[T]): ZIO[LMDB, UpsertErrors, UpsertState[T]] =
+  def upsert[T](collectionName: CollectionName, key: RecordKey, modifier: Option[T] => T)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): ZIO[LMDB, UpsertErrors, UpsertState[T]] =
     ZIO.serviceWithZIO(_.upsert[T](collectionName, key, modifier))
 
-  def upsertOverwrite[T](collectionName: CollectionName, key: RecordKey, document: T)(using JsonEncoder[T], JsonDecoder[T]): ZIO[LMDB, UpsertErrors, UpsertState[T]] =
+  def upsertOverwrite[T](collectionName: CollectionName, key: RecordKey, document: T)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): ZIO[LMDB, UpsertErrors, UpsertState[T]] =
     ZIO.serviceWithZIO(_.upsertOverwrite[T](collectionName, key, document))
 
-  def delete[T](collectionName: CollectionName, key: RecordKey)(using JsonEncoder[T], JsonDecoder[T]): ZIO[LMDB, DeleteErrors, Option[T]] =
+  def delete[T](collectionName: CollectionName, key: RecordKey)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): ZIO[LMDB, DeleteErrors, Option[T]] =
     ZIO.serviceWithZIO(_.delete[T](collectionName, key))
 
-  def collect[T](collectionName: CollectionName, keyFilter: RecordKey => Boolean = _ => true, valueFilter: T => Boolean = (_: T) => true)(using JsonEncoder[T], JsonDecoder[T]): ZIO[LMDB, CollectErrors, List[T]] =
+  def collect[T](collectionName: CollectionName, keyFilter: RecordKey => Boolean = _ => true, valueFilter: T => Boolean = (_: T) => true)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): ZIO[LMDB, CollectErrors, List[T]] =
     ZIO.serviceWithZIO(_.collect[T](collectionName, keyFilter, valueFilter))
 
-  //def stream[T](collectionName: CollectionName, keyFilter: RecordKey => Boolean = _ => true)(using JsonEncoder[T], JsonDecoder[T]): ZStream[Scope & LMDB, CollectErrors, T] = // TODO implement stream in LMDB service
+  //def stream[T](collectionName: CollectionName, keyFilter: RecordKey => Boolean = _ => true)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]): ZStream[Scope & LMDB, CollectErrors, T] = // TODO implement stream in LMDB service
   //  ZStream.serviceWithZIO(_.stream(collectionName, keyFilter))
 
   val live: ZLayer[Scope & LMDBConfig, Any, LMDB] = ZLayer(ZIO.service[LMDBConfig].flatMap(LMDBLive.setup)).orDie

--- a/src/main/scala/zio/lmdb/LMDBCollection.scala
+++ b/src/main/scala/zio/lmdb/LMDBCollection.scala
@@ -15,10 +15,8 @@
  */
 package zio.lmdb
 
-import zio.*
+import zio._
 import zio.json.{JsonDecoder, JsonEncoder}
-import zio.lmdb.StorageUserError.*
-import zio.lmdb.StorageSystemError
 
 /**
  * A helper class to simplify user experience by avoiding repeating collection name and data types
@@ -28,9 +26,9 @@ import zio.lmdb.StorageSystemError
  * @param JsonDecoder[T]
  * @tparam T the data class type for collection content
  */
-case class LMDBCollection[T](name: String, lmdb: LMDB)(using JsonEncoder[T], JsonDecoder[T]) {
+case class LMDBCollection[T](name: String, lmdb: LMDB)(implicit je: JsonEncoder[T], jd: JsonDecoder[T]) {
 
-  def size(): IO[CollectionNotFound | StorageSystemError, Long] = lmdb.collectionSize(name)
+  def size(): IO[LmdbError, Long] = lmdb.collectionSize(name)
 
   def fetch(key: RecordKey): IO[FetchErrors, Option[T]] = lmdb.fetch(name, key)
 

--- a/src/main/scala/zio/lmdb/LMDBConfig.scala
+++ b/src/main/scala/zio/lmdb/LMDBConfig.scala
@@ -17,7 +17,7 @@
 package zio.lmdb
 
 import java.io.File
-import zio.*
+import zio._
 
 case class LMDBConfig(
   databasePath: File,
@@ -42,8 +42,8 @@ object LMDBConfig {
   ): IO[Exception, LMDBConfig] = {
     for {
       home             <- System.envOrElse("HOME", ".")
-      lmdbDatabasesHome = File(home, ".lmdb")
-      databasePath      = File(lmdbDatabasesHome, databaseName)
+      lmdbDatabasesHome = new File(home, ".lmdb")
+      databasePath      = new File(lmdbDatabasesHome, databaseName)
       _                <- ZIO.attemptBlockingIO(databasePath.mkdirs())
       config            = LMDBConfig(databasePath, fileSystemSynchronized = fileSystemSynchronized)
     } yield config

--- a/src/main/scala/zio/lmdb/LMDBIssues.scala
+++ b/src/main/scala/zio/lmdb/LMDBIssues.scala
@@ -16,13 +16,16 @@
 
 package zio.lmdb
 
-enum StorageUserError {
-  case CollectionAlreadExists(name: CollectionName)            extends StorageUserError
-  case CollectionNotFound(name: CollectionName)                extends StorageUserError
-  case JsonFailure(issue: String)                              extends StorageUserError
-  case OverSizedKey(id: String, expandedSize: Int, limit: Int) extends StorageUserError
+trait LmdbError
+trait StorageUserError extends LmdbError
+object StorageUserError {
+  case class CollectionAlreadExists(name: CollectionName)            extends StorageUserError
+  case class CollectionNotFound(name: CollectionName)                extends StorageUserError
+  case class JsonFailure(issue: String)                              extends StorageUserError
+  case class OverSizedKey(id: String, expandedSize: Int, limit: Int) extends StorageUserError
 }
 
-enum StorageSystemError {
-  case InternalError(message: String, cause: Option[Throwable] = None) extends StorageSystemError
+trait StorageSystemError extends LmdbError
+object StorageSystemError {
+  case class InternalError(message: String, cause: Option[Throwable] = None) extends StorageSystemError
 }

--- a/src/main/scala/zio/lmdb/UpsertState.scala
+++ b/src/main/scala/zio/lmdb/UpsertState.scala
@@ -16,4 +16,4 @@
 
 package zio.lmdb
 
-case class UpsertState[T](previous:Option[T], current: T)
+case class UpsertState[T](previous: Option[T], current: T)

--- a/src/main/scala/zio/lmdb/package.scala
+++ b/src/main/scala/zio/lmdb/package.scala
@@ -16,15 +16,15 @@
 
 package zio
 
-import zio.lmdb.StorageUserError.*
+import zio.lmdb.StorageUserError._
 
 package object lmdb {
   type CollectionName = String
   type RecordKey      = String
 
-  type FetchErrors    = OverSizedKey | CollectionNotFound | JsonFailure | StorageSystemError
-  type UpsertErrors   = OverSizedKey | CollectionNotFound | JsonFailure | StorageSystemError
-  type DeleteErrors   = OverSizedKey | CollectionNotFound | JsonFailure | StorageSystemError
-  type CollectErrors  = CollectionNotFound | JsonFailure | StorageSystemError
+  type FetchErrors    = LmdbError
+  type UpsertErrors   = LmdbError
+  type DeleteErrors   = LmdbError
+  type CollectErrors  = LmdbError
 
 }

--- a/src/test/scala/zio/lmdb/LMDBBasicUsageSpec.scala
+++ b/src/test/scala/zio/lmdb/LMDBBasicUsageSpec.scala
@@ -15,14 +15,14 @@
  */
 package zio.lmdb
 
-import zio.*
-import zio.test.*
-import zio.json.*
+import zio._
+import zio.test._
+import zio.json._
 import zio.nio.file.Files
 
 case class Record(name: String, age: Long)
 object Record {
-  given JsonCodec[Record] = DeriveJsonCodec.gen
+  implicit val jsonCodecRecord: JsonCodec[Record] = DeriveJsonCodec.gen
 }
 
 object LMDBBasicUsageSpec extends ZIOSpecDefault {

--- a/src/test/scala/zio/lmdb/LMDBLiveSpec.scala
+++ b/src/test/scala/zio/lmdb/LMDBLiveSpec.scala
@@ -15,15 +15,15 @@
  */
 package zio.lmdb
 
-import zio.*
-import zio.json.*
+import zio._
+import zio.json._
 import zio.json.ast.Json
-import zio.json.ast.Json.*
-import zio.nio.file.*
+import zio.json.ast.Json._
+import zio.nio.file._
 import zio.stream.{ZSink, ZStream}
-import zio.test.*
-import zio.test.Gen.*
-import zio.test.TestAspect.*
+import zio.test._
+import zio.test.Gen._
+import zio.test.TestAspect._
 
 import java.util.UUID
 import java.util.concurrent.TimeUnit


### PR DESCRIPTION
This PR allows to use `zio-lmdb` with scala 2.13 up to the state where all tests pass. 

The main changes are: 

- in build, the only change necessary is Scala version
- there is a lot of small syntactic changes, 
- there is one bigger change in the error ADT 

*Syntactic changes*

- changing `*` by `_` in import
- adding `new` when calling java `File` constructor
- changing `using JsonEncoder[T], JsonDecoder[T]` to `implicit je: JsonEncoder[T], jd: JsonDecoder[T]`
- changing `given xxx` by `implicit val jsonCodecRecord ...`
- using `xxx:_*` for repeated parameter
- adding `case` and curly-braces for `flatMap`, `filter` etc with object decomposition

*Error ADT*

`zio-lmdb` uses scala 3 powerful `|` types to be very precise on error types returned by each function. This is a very nice feature of scala 3 which goes extremely well with `zio` error channel. 
In scala 2, errors must be part of some ADT (one or several), and these ADTs and their hierarchy lead to what error types are returned. We don't have the leisure to be both precise and at the same time practical. 

First, to let the user have something meaningful when using several function from the lib, the unification of error types must reamin somehow meaningful. So we need a general main error trait for LMDB errors which will be extended by all other errors. 
This is necessary to avoir having a unification to `AnyObject` at some point, which is not nice for the user. 

Then, we could imagine having a sub-trait by set of errors commonly together in function error channel. But it leads to a complicated multi-stage hierarchy, and the actual gain is minimal: unification will climb up the hierarchy quickly. Finaly, that solution would lead a rather big change between the scala 2.3 and the scala 3 code and actual traits. 

So it was chosen to keep existing `enum`, just transform them in traits, and make them extends the new `LmdbError` super-type. 
Then, in all the library, the error channel just always return `LmdbError`. This solution works at scale (we use that pattern in https://github.com/Normation/rudder/ which is hundred of thousand line of code) and is nice to use both from the function-definition and the call-site point of view. Of course, we loose specificity but we can keep some of it by either being specific about which of the sub-case-object are returned in some function (unification will be ok), or by `mapError`ing where it matters. 